### PR TITLE
Correct resetup calls to first unsetup then setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,56 @@
 # Dartmud-Lua-Scipts
 
-Hi! If you're here that means you're interested in the dartmud scripts.
+**<p bold align="center">A [Mudlet](https://www.mudlet.org/) package for playing [DartMUD](http://dartmud.com).</p>**
 
-My apologies but they are not ready yet. Check back later, a week or two, and they should be finished.
+## Features
+DartMUDlet does a number of things for you automatically including the obvious visual items like a conversation window up top, your status persisted in the top right.  It also performs the all-important task of counting and reporting improves (for you and for pets), it handles delaying any new commands to the MUD when you are performing interruptable actions like spellcasting and scrollwork, and has many more features useful to DartMUD players.
 
-Thank you for your interest!
+## How to use?
+Aside from the automatic features described above, there are a few things you can control by entering directives in the mud's text entry box:
+
+```
+/setup   - Initialize variables, customize the display, start improve tracking database.
+/unsetup - Remove timers and triggers, deactivate display customizations.
+/resetup - Remove then reinitialize timers, triggers, etc.  Makes changes to DartMUDLet active.
+```
+```
+/announce on      - Announce improvements in Brief mode (just a plus, no skill name revealed)
+/announce verbose - Announce improvements including the full name of the skill
+/announce off     - Stop announcing improvements
+```
+```
+/antispam on|off - suppress repeated lines
+```
+```
+/block   - Block any new commands from being sent to the MUD, queue them to be sent later.
+           DartMUDlet usually does this for you when it detects the start of interuptable actions.
+/unblock - Resume sending commands to the MUD starting with any that were queued while blocking.
+           For when you MUST interrupt your previous action (e.g. to run from that dragon NOW).
+```
+```
+/cast ! <spell> @ <power> <spell args> - Repeat practice casting a spell
+/cast ! off                            - Stop practicing; remember spell and power
+/cast ! resume [<spell>]               - Resume practing last/named spell at the previous power
+/cast ! status [of <spell>]            - Show power used for last/named spell
+```
+```
+/channel <power> <target>     - Repeat channelling aura to target, count how many times you did 
+/channel off                  - Stop channelling, save target and power level for future resume
+/channel resume [<target>]    - Resume channelling last/named target at previous power
+/channel status [of <target>] - Show power channeled to last/named target
+```
+```
+/inscribe ! <spell> @ <power> - Repeat practice inscribing a spell at the given power 
+/inscribe ! off               - Stop practice inscribing 
+/inscribe ! resume [<spell>]  - Resume practice inscribing the last/named spell at last power 
+/inscribe ! adjust  power <power> - Change the power you are using for each practice
+/inscribe ! status [of <spell>]   - Show power used for last/named spell
+```
+```
+/update <who> <skill> <improves> - Set improves for your (or pet's) skill to given total
+/info <skill>                    - Shows current improves/level and improves to reach next
+```
+```
+/who on  - Check who is online every 5 minutes; results are updated in persistent custom area
+/who off - Stop issuing automatic checks every 5 minutes; manual 'who' still updates display
+```

--- a/Scripts/AntiSpam.lua
+++ b/Scripts/AntiSpam.lua
@@ -79,8 +79,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
-  setup(args)
   unsetup(args)
+  setup(args)
 end
 
 local function loaderFunction(sentTable)

--- a/Scripts/Events.lua
+++ b/Scripts/Events.lua
@@ -16,8 +16,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
-  setup(args)
   unsetup(args)
+  setup(args)
 end
 
 local function createEventList(eventName)

--- a/Timers/Score.lua
+++ b/Timers/Score.lua
@@ -34,8 +34,8 @@ local function unsetup()
 end
 
 local function resetup()
+  unsetup()
   setup()
-  resetup()
 end
 
 Score = {

--- a/Timers/UI_Timers.lua
+++ b/Timers/UI_Timers.lua
@@ -32,8 +32,8 @@ local function unsetup()
 end
 
 local function resetup()
+  unsetup()
   setup()
-  resetup()
 end
 
 UI_Timers = {

--- a/Triggers/Age_Triggers.lua
+++ b/Triggers/Age_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Youth = {

--- a/Triggers/Alignment_Triggers.lua
+++ b/Triggers/Alignment_Triggers.lua
@@ -27,8 +27,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Alignment = {

--- a/Triggers/Any.lua
+++ b/Triggers/Any.lua
@@ -24,10 +24,10 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
-
+  
 Any = {
   setup = setup
   ,unsetup = unsetup

--- a/Triggers/Aura_Triggers.lua
+++ b/Triggers/Aura_Triggers.lua
@@ -277,8 +277,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Aura = {

--- a/Triggers/Blocking_Triggers.lua
+++ b/Triggers/Blocking_Triggers.lua
@@ -47,8 +47,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Blocking = {

--- a/Triggers/Casting_Triggers.lua
+++ b/Triggers/Casting_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Casting = {

--- a/Triggers/Chat_Triggers.lua
+++ b/Triggers/Chat_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Chat = {

--- a/Triggers/Concentration_Triggers.lua
+++ b/Triggers/Concentration_Triggers.lua
@@ -98,8 +98,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Concentration = {

--- a/Triggers/Encumberance_Triggers.lua
+++ b/Triggers/Encumberance_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Encumberance = {

--- a/Triggers/Hunger_Triggers.lua
+++ b/Triggers/Hunger_Triggers.lua
@@ -96,8 +96,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Hunger = {

--- a/Triggers/Inscribing_Triggers.lua
+++ b/Triggers/Inscribing_Triggers.lua
@@ -34,8 +34,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Inscribing = {

--- a/Triggers/Login_Triggers.lua
+++ b/Triggers/Login_Triggers.lua
@@ -30,8 +30,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Login = {

--- a/Triggers/Movement_Triggers.lua
+++ b/Triggers/Movement_Triggers.lua
@@ -84,8 +84,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Movement = {

--- a/Triggers/Name_Triggers.lua
+++ b/Triggers/Name_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Name = {

--- a/Triggers/Race_Triggers.lua
+++ b/Triggers/Race_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Race = {

--- a/Triggers/Skill_Triggers.lua
+++ b/Triggers/Skill_Triggers.lua
@@ -47,8 +47,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Skill_Triggers = {

--- a/Triggers/SoulAge_Triggers.lua
+++ b/Triggers/SoulAge_Triggers.lua
@@ -30,8 +30,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 SoulAge = {

--- a/Triggers/Thirst_Triggers.lua
+++ b/Triggers/Thirst_Triggers.lua
@@ -82,8 +82,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Thirst = {

--- a/Triggers/Who_Triggers.lua
+++ b/Triggers/Who_Triggers.lua
@@ -66,8 +66,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Who_Triggers = {


### PR DESCRIPTION
A few of the resetup calls did things in the wrong order, calling setup followed by unsetup and several others called didn't call unsetup at all and made calls to resetup within resetup.  This patch corrects all instances of local resetup() calls to be defined as local unsetup() followed by local setup().