### PR TITLE
Correct resetup calls to first unsetup then setup.

### DIFF
--- a/Scripts/AntiSpam.lua
+++ b/Scripts/AntiSpam.lua
@@ -79,8 +79,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
-  setup(args)
   unsetup(args)
+  setup(args)
 end
 
 local function loaderFunction(sentTable)

--- a/Scripts/Events.lua
+++ b/Scripts/Events.lua
@@ -16,8 +16,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
-  setup(args)
   unsetup(args)
+  setup(args)
 end
 
 local function createEventList(eventName)

--- a/Timers/Score.lua
+++ b/Timers/Score.lua
@@ -34,8 +34,8 @@ local function unsetup()
 end
 
 local function resetup()
+  unsetup()
   setup()
-  resetup()
 end
 
 Score = {

--- a/Timers/UI_Timers.lua
+++ b/Timers/UI_Timers.lua
@@ -32,8 +32,8 @@ local function unsetup()
 end
 
 local function resetup()
+  unsetup()
   setup()
-  resetup()
 end
 
 UI_Timers = {

--- a/Triggers/Age_Triggers.lua
+++ b/Triggers/Age_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Youth = {

--- a/Triggers/Alignment_Triggers.lua
+++ b/Triggers/Alignment_Triggers.lua
@@ -27,8 +27,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Alignment = {

--- a/Triggers/Any.lua
+++ b/Triggers/Any.lua
@@ -24,10 +24,10 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
-
+  
 Any = {
   setup = setup
   ,unsetup = unsetup

--- a/Triggers/Aura_Triggers.lua
+++ b/Triggers/Aura_Triggers.lua
@@ -277,8 +277,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Aura = {

--- a/Triggers/Blocking_Triggers.lua
+++ b/Triggers/Blocking_Triggers.lua
@@ -47,8 +47,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Blocking = {

--- a/Triggers/Casting_Triggers.lua
+++ b/Triggers/Casting_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Casting = {

--- a/Triggers/Chat_Triggers.lua
+++ b/Triggers/Chat_Triggers.lua
@@ -24,8 +24,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Chat = {

--- a/Triggers/Concentration_Triggers.lua
+++ b/Triggers/Concentration_Triggers.lua
@@ -98,8 +98,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Concentration = {

--- a/Triggers/Encumberance_Triggers.lua
+++ b/Triggers/Encumberance_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Encumberance = {

--- a/Triggers/Hunger_Triggers.lua
+++ b/Triggers/Hunger_Triggers.lua
@@ -96,8 +96,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Hunger = {

--- a/Triggers/Inscribing_Triggers.lua
+++ b/Triggers/Inscribing_Triggers.lua
@@ -34,8 +34,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Inscribing = {

--- a/Triggers/Login_Triggers.lua
+++ b/Triggers/Login_Triggers.lua
@@ -30,8 +30,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Login = {

--- a/Triggers/Movement_Triggers.lua
+++ b/Triggers/Movement_Triggers.lua
@@ -84,8 +84,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Movement = {

--- a/Triggers/Name_Triggers.lua
+++ b/Triggers/Name_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Name = {

--- a/Triggers/Race_Triggers.lua
+++ b/Triggers/Race_Triggers.lua
@@ -25,8 +25,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Race = {

--- a/Triggers/Skill_Triggers.lua
+++ b/Triggers/Skill_Triggers.lua
@@ -47,8 +47,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Skill_Triggers = {

--- a/Triggers/SoulAge_Triggers.lua
+++ b/Triggers/SoulAge_Triggers.lua
@@ -30,8 +30,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 SoulAge = {

--- a/Triggers/Thirst_Triggers.lua
+++ b/Triggers/Thirst_Triggers.lua
@@ -82,8 +82,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Thirst = {

--- a/Triggers/Who_Triggers.lua
+++ b/Triggers/Who_Triggers.lua
@@ -66,8 +66,8 @@ local function unsetup(args)
 end
 
 local function resetup(args)
+  unsetup(args)
   setup(args)
-  resetup(args)
 end
 
 Who_Triggers = {


### PR DESCRIPTION
A few of the resetup calls did things in the wrong order, calling setup followed by unsetup and several others called didn't call unsetup at all and made calls to resetup within resetup. This patch corrects all instances of local resetup() calls to be defined as local unsetup() followed by local setup().