### PR TITLE
Catch who banners that are 3 characters long

### DIFF
--- a/Triggers/Who_Triggers.lua
+++ b/Triggers/Who_Triggers.lua
@@ -13,7 +13,7 @@ local function setup(args)
                 ]])
 
   tempTriggers.whoNames =
-    tempRegexTrigger("^(?:> )?(?: {7}| {2}(?:\\[[A-Za-z]+\\] ))(?:([A-Za-z\-]+ [A-Za-z\-]+ [A-Za-z\-]+)( +)(?:(?:Idle *(?:\\d+m)? ?(?:\\d+s)?)|Online)?)+ *?"
+    tempRegexTrigger("^(?:> )?(?: {7}| {1,2}(?:\\[[A-Za-z]+\\] ))(?:([A-Za-z\-]+ [A-Za-z\-]+ [A-Za-z\-]+)( +)(?:(?:Idle *(?:\\d+m)? ?(?:\\d+s)?)|Online)?)+ *?"
                ,[[
                   args = {name = name}
                   Events.raiseEvent("whoEvent", args)


### PR DESCRIPTION
Some guilds like the Rangers of Eristan now have who banners like [RoE] that are more than 2 characters.  The existing regex doesn't account for anything other than 2 character banners so these end up in the main window rather than being suppressed and updated in the persistent 'who' display.